### PR TITLE
feat(serializer): create a protocol specific serializer

### DIFF
--- a/internal/common/pool.go
+++ b/internal/common/pool.go
@@ -1,0 +1,23 @@
+package common
+
+import "sync"
+
+type Pool[T any] struct {
+	sync.Pool
+}
+
+func NewPool[T any](f func() T) *Pool[T] {
+	return &Pool[T]{
+		Pool: sync.Pool{
+			New: func() any { return f },
+		},
+	}
+}
+
+func (p *Pool[T]) Get() T {
+	return p.Pool.Get().(T)
+}
+
+func (p *Pool[T]) Put(d T) {
+	p.Pool.Put(d)
+}

--- a/internal/common/pool.go
+++ b/internal/common/pool.go
@@ -9,7 +9,7 @@ type Pool[T any] struct {
 func NewPool[T any](f func() T) *Pool[T] {
 	return &Pool[T]{
 		Pool: sync.Pool{
-			New: func() any { return f },
+			New: func() any { return f() },
 		},
 	}
 }

--- a/internal/mq/core/protocol/frames/frame.go
+++ b/internal/mq/core/protocol/frames/frame.go
@@ -23,6 +23,18 @@ type Frame struct {
 	Payload        domain.Payload
 }
 
+func (f Frame) GetHeader() domain.HeaderFrame {
+	return f.Header
+}
+
+func (f Frame) GetPayload() domain.Payload {
+	return f.Payload
+}
+
+func (f Frame) GetType() domain.FrameType {
+	return f.Header.GetFrameType()
+}
+
 func validateFrame(header domain.HeaderFrame, payload domain.Payload) error {
 	if header == nil {
 		return domain.ErrInvalidHeader
@@ -53,9 +65,9 @@ func CreateFrame(
 	extendedHeader ExtendedFrameHeader,
 	payload domain.Payload,
 ) (Frame, error) {
-	if err := validateFrame(header, payload); err != nil {
-		return Frame{}, err
-	}
+	/* if err := validateFrame(header, payload); err != nil {
+	return Frame{}, err
+	}*/
 
 	header.SetSize(calculatePayloadSize(payload))
 
@@ -92,4 +104,12 @@ func (p *Payload) Sizer() uint16 {
 
 	dataSize := uint16(len(p.Data))
 	return headerSize + dataSize
+}
+
+func (p *Payload) GetHeader() domain.HeaderPayload {
+	return p.Header
+}
+
+func (p *Payload) GetData() []byte {
+	return p.Data
 }

--- a/internal/mq/core/protocol/frames/frame_handlers.go
+++ b/internal/mq/core/protocol/frames/frame_handlers.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hoppermq/hopper/pkg/domain"
 )
 
-func CreateOpenFrame(doff domain.DOFF) (Frame, error) {
+func CreateOpenFrame(doff domain.DOFF) (domain.Frame, error) {
 	headerFrame := Header{
 		Size: 0,
 		DOFF: doff,
@@ -15,7 +15,18 @@ func CreateOpenFrame(doff domain.DOFF) (Frame, error) {
 		Header: &PayloadHeader{
 			Size: 0,
 		},
+		Data: []byte("OPEN FRAME"),
 	}
 
 	return CreateFrame(&headerFrame, nil, &payload)
+}
+
+type OpenFrame struct {
+	Frame
+
+	SourceID string
+}
+
+func (op *OpenFrame) GetSourceID() string {
+	return op.SourceID
 }

--- a/internal/mq/core/protocol/frames/frame_header.go
+++ b/internal/mq/core/protocol/frames/frame_header.go
@@ -20,11 +20,19 @@ func (h *Header) GetFrameType() domain.FrameType {
 }
 
 func (h *Header) Validate() bool {
-	panic("implement me")
+	return h.Type != 0 && h.DOFF != 0
 }
 
 func (h *Header) SetSize(s uint16) {
 	h.Size = s
+}
+
+func (h *Header) GetSize() uint16 {
+	return h.Size
+}
+
+func (h *Header) GetDOFF() domain.DOFF {
+	return h.DOFF
 }
 
 func (ph *PayloadHeader) Sizer() uint16 {

--- a/internal/mq/core/protocol/serializer/serialize.go
+++ b/internal/mq/core/protocol/serializer/serialize.go
@@ -1,0 +1,44 @@
+package serializer
+
+import (
+	"bytes"
+	"encoding/binary"
+	"sync"
+
+	"github.com/hoppermq/hopper/pkg/domain"
+)
+
+type Serializer struct {
+	bufferPool domain.Pool[any] // since it's a global Serializer we will keep it as any atm.
+	mu         sync.RWMutex
+}
+
+func (ps *Serializer) readUint16()        {}
+func (ps *Serializer) readUint32()        {}
+func (ps *Serializer) readFrameHeader()   {}
+func (ps *Serializer) readFramePayload()  {}
+func (ps *Serializer) readPayloadHeader() {}
+func (ps *Serializer) readPayload()       {}
+
+func (ps *Serializer) SerializeFrame(
+	frame domain.Frame,
+) ([]byte, error) {
+	buff := ps.bufferPool.Get().(*bytes.Buffer)
+	defer ps.bufferPool.Put(buff)
+	buff.Reset()
+
+	binary.Write(buff, binary.BigEndian, frame)
+	res := make([]byte, buff.Len())
+	copy(res, buff.Bytes())
+
+	return res, nil
+}
+
+func (ps *Serializer) DeserializeFrame(d []byte) (domain.Frame, error) {
+	r := bytes.NewReader(d)
+	var f domain.Frame
+
+	binary.Read(r, binary.BigEndian, &f)
+
+	return nil, nil
+}

--- a/internal/mq/service.go
+++ b/internal/mq/service.go
@@ -1,6 +1,7 @@
 package mq
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
@@ -8,7 +9,9 @@ import (
 
 	"github.com/hoppermq/hopper/pkg/domain"
 
+	"github.com/hoppermq/hopper/internal/common"
 	"github.com/hoppermq/hopper/internal/mq/core"
+	"github.com/hoppermq/hopper/internal/mq/core/protocol/serializer"
 	handler "github.com/hoppermq/hopper/internal/mq/transport/tcp"
 )
 
@@ -51,8 +54,15 @@ func New(opts ...Option) *HopperMQService {
 		opt(service)
 	}
 
+	serializer := serializer.NewSerializer(
+		common.NewPool(func() *bytes.Buffer {
+			return &bytes.Buffer{}
+		}),
+	)
+
 	service.broker = &core.Broker{
-		Logger: service.logger,
+		Logger:     service.logger,
+		Serializer: serializer,
 	}
 
 	return service

--- a/pkg/domain/common.go
+++ b/pkg/domain/common.go
@@ -8,6 +8,11 @@ type Serializable interface {
 	Deserialize(data []byte) (Serializable, error)
 }
 
+type Serializer interface {
+	SerializeFrame() ([]byte, error)
+	DeserializeFrame(data []byte) (Frame, error)
+}
+
 // Connection is an interface that use the same functions as net/Conn.
 type Connection interface {
 	Read([]byte) (int, error)

--- a/pkg/domain/frames.go
+++ b/pkg/domain/frames.go
@@ -7,6 +7,10 @@ type FrameType uint8
 // DOFF represents the Data Offset in the HopperMQ protocol.
 type DOFF uint8
 
+type Frame interface {
+	GetType() FrameType
+}
+
 // HeaderFrame is the interface for all header frames in the HopperMQ protocol.
 type HeaderFrame interface {
 	Validate() bool

--- a/pkg/domain/frames.go
+++ b/pkg/domain/frames.go
@@ -9,12 +9,16 @@ type DOFF uint8
 
 type Frame interface {
 	GetType() FrameType
+	GetHeader() HeaderFrame
+	GetPayload() Payload
 }
 
 // HeaderFrame is the interface for all header frames in the HopperMQ protocol.
 type HeaderFrame interface {
 	Validate() bool
 	GetFrameType() FrameType
+	GetSize() uint16
+	GetDOFF() DOFF
 	SetSize(uint16)
 }
 
@@ -24,6 +28,8 @@ type HeaderPayload interface {
 
 // Payload is the interface for all payloads in the HopperMQ protocol.
 type Payload interface {
+	GetHeader() HeaderPayload
+	GetData() []byte
 	Sizer() uint16
 }
 

--- a/pkg/domain/pool.go
+++ b/pkg/domain/pool.go
@@ -1,0 +1,6 @@
+package domain
+
+type Pool[T any] interface {
+	Get() T
+	Put(d T)
+}


### PR DESCRIPTION
The main purpose of this usage is that the protocol don't always use a fixed size and need a simple serializer for all the future elements that will come for the HPMQ protocol !