### PR TITLE
refactor(openFrame): change `assignedChannelID` to `AssignedContainerID`

### DIFF
--- a/internal/mq/core/broker.go
+++ b/internal/mq/core/broker.go
@@ -105,13 +105,13 @@ func (b *Broker) onNewClientConnection(ctx context.Context, evt *events.NewConne
 	b.Logger.Info(
 		"Container Created",
 		"container_id",
-		ctnr.(*container.Container).ID,
+		ctnr.GetID(),
 		"current_state",
 		ctnr.(*container.Container).State,
 	)
 	openFramePayloadData := frames.CreateOpenFramePayloadData(
-		string(client.ID),
-		string(GenerateIdentifier()),
+		client.ID,
+		ctnr.GetID(),
 	)
 
 	data, err := b.Serializer.SerializeOpenFramePayloadData(openFramePayloadData)

--- a/internal/mq/core/protocol/container/container.go
+++ b/internal/mq/core/protocol/container/container.go
@@ -73,3 +73,7 @@ func (ctnr *Container) findChannelByID(ID domain.ID) domain.Channel {
 func (ctnr *Container) SetState(state domain.ContainerState) {
 	ctnr.State = state
 }
+
+func (ctnr *Container) GetID() domain.ID {
+	return ctnr.ID
+}

--- a/internal/mq/core/protocol/container/manager.go
+++ b/internal/mq/core/protocol/container/manager.go
@@ -24,7 +24,7 @@ func (ctnrManager *ContainerManager) CreateNewContainer(
 ) domain.Container {
 	println("HELLO ??")
 	container := NewContainer(IDGenerator(), clientID)
-	ctnrManager.Container[container.(*Container).ID] = container
+	ctnrManager.Container[container.GetID()] = container
 
 	return container
 }

--- a/internal/mq/core/protocol/frames/open_frame.go
+++ b/internal/mq/core/protocol/frames/open_frame.go
@@ -1,21 +1,23 @@
 package frames
 
+import "github.com/hoppermq/hopper/pkg/domain"
+
 type OpenFrame struct {
 	Frame
 }
 
 type OpenFramePayloadData struct {
-	SourceID       string
-	AssignedChanID string
+	SourceID            domain.ID
+	AssignedContainerID domain.ID
 }
 
-func (op *OpenFramePayloadData) GetSourceID() string {
+func (op *OpenFramePayloadData) GetSourceID() domain.ID {
 	return op.SourceID
 }
 
-func CreateOpenFramePayloadData(sourceID string, assignedChannel string) *OpenFramePayloadData {
+func CreateOpenFramePayloadData(sourceID domain.ID, assignedContainerID domain.ID) *OpenFramePayloadData {
 	return &OpenFramePayloadData{
-		SourceID:       sourceID,
-		AssignedChanID: assignedChannel,
+		SourceID:            sourceID,
+		AssignedContainerID: assignedContainerID,
 	}
 }

--- a/internal/mq/core/protocol/serializer/serialize.go
+++ b/internal/mq/core/protocol/serializer/serialize.go
@@ -39,6 +39,15 @@ func (ps *Serializer) writeString(b *bytes.Buffer, str string) error {
 	return err
 }
 
+func (ps *Serializer) writeID(b *bytes.Buffer, ID domain.ID) error {
+	if err := ps.writeUint32(b, uint32(len(ID))); err != nil {
+		return err
+	}
+
+	_, err := b.Write([]byte(ID))
+	return err
+}
+
 func (ps *Serializer) writeFrameHeader(buff *bytes.Buffer, fh domain.HeaderFrame) error {
 	if err := ps.writeUint16(buff, fh.GetSize()); err != nil {
 		return err
@@ -86,11 +95,11 @@ func (ps *Serializer) SerializeOpenFramePayloadData(data *frames.OpenFramePayloa
 	defer ps.bufferPool.Put(buff)
 	buff.Reset()
 
-	if err := ps.writeString(buff, data.AssignedChanID); err != nil {
+	if err := ps.writeID(buff, data.AssignedContainerID); err != nil {
 		return nil, err
 	}
 
-	if err := ps.writeString(buff, data.SourceID); err != nil {
+	if err := ps.writeID(buff, data.SourceID); err != nil {
 		return nil, err
 	}
 

--- a/pkg/domain/container.go
+++ b/pkg/domain/container.go
@@ -23,6 +23,7 @@ type Container interface {
 	CreateChannel(topic string, idGenerator func() ID) Channel
 	RemoveChannel(topic string)
 	SetState(state ContainerState)
+	GetID() ID
 }
 
 type Channel interface {


### PR DESCRIPTION
Since container wil handle client message processing it's more logic to assign the container and let the container manage itself